### PR TITLE
Moved to multiple instances with improved settings

### DIFF
--- a/lang/en/repository_opencast.php
+++ b/lang/en/repository_opencast.php
@@ -27,6 +27,8 @@ $string['configplugin'] = 'Opencast settings';
 $string['opencastauthor'] = 'Opencast default author';
 $string['opencastchannelid'] = 'Opencast channelid';
 $string['opencastchannelid_help'] = 'Setup the channelid of the publication channel to search for retrieving url of thumbnail and video.';
+$string['opencastplayerurl'] = 'Embedd URL to player instead of media file.';
+$string['opencastplayerurl_help'] = 'If checked, the URL of the Opencast player is used. Otherwise the repository selects the URL to a video file of the Opencast event.';
 $string['opencastthumbnailflavor'] = 'Preferred flavor to get thumbnail';
 $string['opencastthumbnailflavor_help'] = 'A publication may have several attachments with different flavors.
     Setup the flavor (for example "presenter/search+preview"), that should be used to retrieve the thumbnail url. If there is no attachment with this flavor, the

--- a/lang/en/repository_opencast.php
+++ b/lang/en/repository_opencast.php
@@ -25,4 +25,17 @@
 
 $string['configplugin'] = 'Opencast settings';
 $string['opencastauthor'] = 'Opencast default author';
+$string['opencastchannelid'] = 'Opencast channelid';
+$string['opencastchannelid_help'] = 'Setup the channelid of the publication channel to search for retrieving url of thumbnail and video.';
+$string['opencastthumbnailflavor'] = 'Preferred flavor to get thumbnail';
+$string['opencastthumbnailflavor_help'] = 'A publication may have several attachments with different flavors.
+    Setup the flavor (for example "presenter/search+preview"), that should be used to retrieve the thumbnail url. If there is no attachment with this flavor, the
+    plugin will try to find an attachment with the fallback flavor.';
+$string['opencastthumbnailflavorfallback'] = 'Fallback flavor to get thumbnail';
+$string['opencastthumbnailflavorfallback_help'] = 'Setup the flavor, that should be used, if the there is no attachment with the preferred flavor above is available.
+    If you leave all input for thumbnail search blank, the plugin will automatically try to find a thumbnail url.';
+$string['opencastvideoflavor'] = 'Flavor to get video';
+$string['opencastvideoflavor_help'] = 'A publication may have several attachments with different flavors. Setup a flavor that should be used to retrieve the video url.
+    If you leave this blank, the first available video url found in attachments will be used.';
+$string['opencast:view'] = 'View repository opencast';
 $string['pluginname'] = 'Opencast Videos';

--- a/lib.php
+++ b/lib.php
@@ -82,6 +82,7 @@ class repository_opencast extends repository {
     public function set_option($options = array()) {
         $options['opencast_author'] = clean_param($options['opencast_author'], PARAM_TEXT);
         $options['opencast_channelid'] = clean_param($options['opencast_channelid'], PARAM_TEXT);
+        $options['opencast_playerurl'] = clean_param($options['opencast_playerurl'], PARAM_BOOL);
         $options['opencast_thumbnailflavor'] = clean_param($options['opencast_thumbnailflavor'], PARAM_TEXT);
         $options['opencast_thumbnailflavorfallback'] = clean_param($options['opencast_thumbnailflavorfallback'], PARAM_TEXT);
         $options['opencast_videoflavor'] = clean_param($options['opencast_videoflavor'], PARAM_TEXT);
@@ -99,6 +100,7 @@ class repository_opencast extends repository {
         $instanceoptions = array();
         $instanceoptions [] = 'opencast_author';
         $instanceoptions [] = 'opencast_channelid';
+        $instanceoptions [] = 'opencast_playerurl';
         $instanceoptions [] = 'opencast_thumbnailflavor';
         $instanceoptions [] = 'opencast_thumbnailflavorfallback';
         $instanceoptions [] = 'opencast_videoflavor';
@@ -229,6 +231,8 @@ class repository_opencast extends repository {
             return false;
         }
 
+        $useplayerurl = self::get_option('opencast_playerurl');
+
         foreach ($publications as $publication) {
 
             if ($publication->channel == $channelid) {
@@ -237,8 +241,12 @@ class repository_opencast extends repository {
                 $this->add_video_thumbnail_url($publication, $video);
 
                 // Add a url to video.
-                if ($publication->media) {
-                    $this->add_video_url_and_title($publication, $video);
+                if ($useplayerurl) {
+                    $video->url = $publication->url;
+                } else {
+                    if (!$publication->media || !$this->add_video_url_and_title($publication, $video)) {
+                        return false;
+                    }
                 }
             }
         }

--- a/lib.php
+++ b/lib.php
@@ -36,10 +36,8 @@ use \tool_opencast\local\api;
  */
 class repository_opencast extends repository {
 
-    private $api;
-
     /**
-     * Add Instance settings input to moodle form.
+     * Add type settings input to moodle form.
      *
      * @param moodleform $mform
      * @param string $classname repository class name
@@ -49,17 +47,163 @@ class repository_opencast extends repository {
 
         $mform->addElement('text', 'opencast_author', get_string('opencastauthor', 'repository_opencast'));
         $mform->setType('opencast_author', PARAM_TEXT);
+
+        $mform->addElement('text', 'opencast_channelid', get_string('opencastchannelid', 'repository_opencast'));
+        $mform->setType('opencast_channelid', PARAM_TEXT);
+        $mform->addHelpButton('opencast_channelid', 'opencastchannelid', 'repository_opencast');
+
+        $mform->addElement('text', 'opencast_thumbnailflavor', get_string('opencastthumbnailflavor', 'repository_opencast'));
+        $mform->setType('opencast_thumbnailflavor', PARAM_TEXT);
+        $mform->addHelpButton('opencast_thumbnailflavor', 'opencastthumbnailflavor', 'repository_opencast');
+
+        $mform->addElement('text', 'opencast_thumbnailflavorfallback', get_string('opencastthumbnailflavorfallback', 'repository_opencast'));
+        $mform->setType('opencast_thumbnailflavorfallback', PARAM_TEXT);
+        $mform->addHelpButton('opencast_thumbnailflavorfallback', 'opencastthumbnailflavorfallback', 'repository_opencast');
+
+        $mform->addElement('text', 'opencast_videoflavor', get_string('opencastvideoflavor', 'repository_opencast'));
+        $mform->setType('opencast_videoflavor', PARAM_TEXT);
+        $mform->addHelpButton('opencast_videoflavor', 'opencastvideoflavor', 'repository_opencast');
     }
 
     /**
-     * Return all the valid instance option names.
+     * Return all the valid type option names.
      *
      * @return array
      */
     public static function get_type_option_names() {
+
         $typeoptions = parent::get_type_option_names();
         $typeoptions [] = 'opencast_author';
+        $typeoptions [] = 'opencast_channelid';
+        $typeoptions [] = 'opencast_thumbnailflavor';
+        $typeoptions [] = 'opencast_thumbnailflavorfallback';
+        $typeoptions [] = 'opencast_videoflavor';
+
         return $typeoptions;
+    }
+
+    /**
+     * Get a option for setup for the repository type.
+     *
+     * @param string $optionname
+     * @param string $defaultvalue
+     * @return string
+     */
+    private static function get_type_option($optionname, $defaultvalue = '') {
+
+        // There is a bug in method update_options of the class repository_type,
+        // which we intend to report to moodle tracker. Repository type
+        // uses type name and NOT frankenstyle name to store options in config_plugins.
+        // To make the code work in case this will be fixed we check two ways to retrieve
+        // the data.
+        $value = get_config('repository_opencast', $optionname);
+        if (!empty($value)) {
+            return $value;
+        }
+
+        if (!$value = get_config('opencast', $optionname)) {
+            return $defaultvalue;
+        }
+        return $value;
+    }
+
+    /**
+     * Get channel id for this repository type.
+     * @return string
+     */
+    private function get_channelid() {
+        return self::get_type_option('opencast_channelid', 'api');
+    }
+
+    /**
+     * Get name of author for this repository type.
+     * @return string
+     */
+    private function get_author() {
+        return self::get_type_option('opencast_author');
+    }
+
+    /**
+     * Select the url for the video based on configuration of preferred flavors.
+     *
+     * @param object $publication
+     * @return string
+     */
+    private function add_video_thumbnail_url($publication, &$video) {
+
+        // Try to find a thumbnail url based on configuration.
+        $thumbnailflavor = self::get_type_option('opencast_thumbnailflavor');
+        if (!empty($thumbnailflavor)) {
+            foreach ($publication->attachments as $attachment) {
+                if ($attachment->flavor === $thumbnailflavor) {
+                    $video->thumbnail = $attachment->url;
+                    return true;
+                }
+            }
+        }
+
+        // Try fallback.
+        $thumbnailflavorfallback = self::get_type_option('opencast_thumbnailflavorfallback');
+        if (!empty($thumbnailflavor)) {
+            foreach ($publication->attachments as $attachment) {
+                if ($attachment->flavor === $thumbnailflavorfallback) {
+                    $video->thumbnail = $attachment->url;
+                    return true;
+                }
+            }
+        }
+
+        // Automatically try to find the best preview image:
+        // presentation/search+preview > presenter/search+preview > any other preview
+        foreach ($publication->attachments as $attachment) {
+            if (!empty($attachment->url) && strpos($attachment->flavor, '+preview') > 0) {
+                if (empty($video->url) || strpos($attachment->flavor, '/search+preview') > 0) {
+                    $video->thumbnail = $attachment->url;
+                    if ($attachment->flavor === 'presentation/search+preview') {
+                        return true;
+                    }
+                }
+            }
+        }
+        return false;
+    }
+
+    private function add_video_url_and_title($publication, $video) {
+
+        // Try to find a video by preferred configuration.
+        $videoflavor = self::get_type_option('opencast_videoflavor');
+        if (!empty($videoflavor)) {
+
+            foreach ($publication->media as $media) {
+                if (!empty($media->has_video) && ($media->flavor === $videoflavor)) {
+                    $video->url = $media->url;
+                    // Check mimetype needed for embedding in moodle.
+                    $ending = pathinfo($media->url, PATHINFO_EXTENSION);
+                    $existingending = pathinfo($video->title, PATHINFO_EXTENSION);
+                    if ($ending !== $existingending) {
+                        $video->title .= '.' . $ending;
+                    }
+                    return true;
+                }
+            }
+        }
+
+        // Automatically find a suitable video.
+        foreach ($publication->media as $media) {
+
+            if (!empty($media->has_video)) {
+                $video->url = $media->url;
+                // Check mimetype needed for embedding in moodle.
+                $ending = pathinfo($media->url, PATHINFO_EXTENSION);
+                $existingending = pathinfo($video->title, PATHINFO_EXTENSION);
+                if ($ending !== $existingending) {
+                    $video->title .= '.' . $ending;
+                }
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**
@@ -70,7 +214,8 @@ class repository_opencast extends repository {
      */
     private function add_video_published_data($video) {
 
-        $published = (count($video->publication_status) > 0 && (in_array('api', $video->publication_status)));
+        $channelid = $this->get_channelid();
+        $published = (count($video->publication_status) > 0 && (in_array($channelid, $video->publication_status)));
 
         if (!$published) {
             return false;
@@ -88,33 +233,14 @@ class repository_opencast extends repository {
 
         foreach ($publications as $publication) {
 
-            if ($publication->channel == 'api') {
-                // Try finding the best preview image:
-                // presentation/search+preview > presenter/search+preview > any other preview
-                foreach ($publication->attachments as $attachment) {
-                    if (!empty($attachment->url) && strpos($attachment->flavor, '+preview') > 0) {
-                        if (!isset($video->thumbnail) || strpos($attachment->flavor, '/search+preview') > 0) {
-                            $video->thumbnail = $attachment->url;
-                            if ($attachment->flavor === 'presentation/search+preview') {
-                                break;
-                            }
-                        }
-                    }
-                }
+            if ($publication->channel == $channelid) {
 
+                // Add a suitable thumbnail url.
+                $this->add_video_thumbnail_url($publication, $video);
+
+                // Add a url to video.
                 if ($publication->media) {
-                    foreach ($publication->media as $media) {
-                        if (!empty($media->has_video)) {
-                            $video->url = $media->url;
-                            // Check mimetype needed for embedding in moodle.
-                            $ending = pathinfo($media->url, PATHINFO_EXTENSION);
-                            $existingending = pathinfo($video->title, PATHINFO_EXTENSION);
-                            if ($ending !== $existingending) {
-                                $video->title .= '.' . $ending;
-                            }
-                            return true;
-                        }
-                    }
+                    $this->add_video_url_and_title($publication, $video);
                 }
             }
         }
@@ -136,7 +262,7 @@ class repository_opencast extends repository {
         }
         $seriesfilter = "series:" . $seriesid;
 
-        $query = '/api/events?sign=1&withmetadata=1&withpublications=1&filter='. urlencode($seriesfilter);
+        $query = '/api/events?sign=1&withmetadata=1&withpublications=1&filter=' . urlencode($seriesfilter);
         try {
             $api = new api();
             $videos = $api->oc_get($query);
@@ -187,7 +313,7 @@ class repository_opencast extends repository {
             $listitem['thumbnail'] = $video->thumbnail;
             $listitem['url'] = $video->url;
             $listitem['source'] = $video->url;
-            $listitem['author'] = (!empty($video->creator)) ? $video->creator : $this->get_option('opencast_author');
+            $listitem['author'] = (!empty($video->creator)) ? $video->creator : $this->get_author();
             $ret['list'][] = $listitem;
         }
 
@@ -200,6 +326,26 @@ class repository_opencast extends repository {
 
     public function supported_filetypes() {
         return array('video');
+    }
+
+    public function phpu_adapter_test_listing($publications, $video) {
+
+        $channelid = $this->get_channelid();
+
+        foreach ($publications as $publication) {
+
+            if ($publication->channel == $channelid) {
+
+                // Add a suitable thumbnail url.
+                $this->add_video_thumbnail_url($publication, $video);
+
+                // Add a url to video.
+                if ($publication->media) {
+                    $this->add_video_url_and_title($publication, $video);
+                }
+            }
+        }
+        return $video;
     }
 
 }

--- a/lib.php
+++ b/lib.php
@@ -51,6 +51,7 @@ class repository_opencast extends repository {
         $mform->addElement('text', 'opencast_channelid', get_string('opencastchannelid', 'repository_opencast'));
         $mform->setType('opencast_channelid', PARAM_TEXT);
         $mform->addHelpButton('opencast_channelid', 'opencastchannelid', 'repository_opencast');
+        $mform->addRule('opencast_channelid', get_string('required'), 'required', null, 'client');
 
         $mform->addElement('text', 'opencast_thumbnailflavor', get_string('opencastthumbnailflavor', 'repository_opencast'));
         $mform->setType('opencast_thumbnailflavor', PARAM_TEXT);

--- a/tests/fixtures/testdata.js
+++ b/tests/fixtures/testdata.js
@@ -1,0 +1,127 @@
+[
+    {
+        "metadata": [],
+        "attachments": [
+            {
+                "flavor": "presenter/player+preview",
+                "ref": "track:f1a9d3c7-80f8-4d6d-b119-295bb3bdf2be",
+                "size": 0,
+                "checksum": "",
+                "id": "8bc36bd5-cbfb-409e-94da-51254279c67d",
+                "mediatype": "image/png",
+                "url": "tn_presenter_player_preview_1.png",
+                "tags": [
+                    "player-download"
+                ]
+            },
+            {
+                "flavor": "presenter/search+preview",
+                "ref": "track:f1a9d3c7-80f8-4d6d-b119-295bb3bdf2be",
+                "size": 0,
+                "checksum": "",
+                "id": "aba5580f-52b1-4919-b893-76e0f4fd877a",
+                "mediatype": "image/png",
+                "url": "tn_presenter_search_preview_1.png",
+                "tags": [
+                    "api-thumbnail",
+                    "player-download"
+                ]
+            },
+            {
+                "flavor": "presenter/player+preview",
+                "ref": "track:track-7",
+                "size": 0,
+                "checksum": "",
+                "id": "86ab7288-7021-4198-a2be-5ebb844ff4e0",
+                "mediatype": "image/png",
+                "url": "tn_presenter_player_preview_2.png",
+                "tags": [
+                    "player-download"
+                ]
+            },
+            {
+                "flavor": "presentation/search+preview",
+                "ref": "track:track-7",
+                "size": 0,
+                "checksum": "",
+                "id": "d7b2b174-083f-480a-8d7a-bf89b17f48b6",
+                "mediatype": "image/png",
+                "url": "tn_presentation_search_preview_1.png",
+                "tags": [
+                    "api-thumbnail",
+                    "player-download"
+                ]
+            }
+        ],
+        "channel": "switchcast-player",
+        "id": "1463b37c-df53-4fb6-98d5-2aa0956ad26f",
+        "media": [
+            {
+                "has_audio": true,
+                "framerate": 25,
+                "description": "",
+                "bitrate": 281569,
+                "url": "h264-540p.mp4",
+                "has_video": true,
+                "tags": [
+                    "player-download",
+                    "tube-download"
+                ],
+                "flavor": "delivery/h264-540p",
+                "duration": 52200,
+                "size": -1,
+                "framecount": 1305,
+                "checksum": "5cb159ae1f389ed33496e3cd0ae9568d (md5)",
+                "width": 960,
+                "id": "596392c4-979d-4efa-a728-902b163e3e37",
+                "mediatype": "video/mp4",
+                "height": 540
+            },
+            {
+                "has_audio": true,
+                "framerate": 25,
+                "description": "",
+                "bitrate": 732434,
+                "url": "h264-720p.mp4",
+                "has_video": true,
+                "tags": [
+                    "download",
+                    "player-download",
+                    "tube-download"
+                ],
+                "flavor": "delivery/h264-720p",
+                "duration": 52200,
+                "size": -1,
+                "framecount": 1305,
+                "checksum": "d7360ae1f8b58e0dd8a863f05ebb6455 (md5)",
+                "width": 1280,
+                "id": "0567a32d-85d9-454b-b759-f784fc33b4eb",
+                "mediatype": "video/mp4",
+                "height": 720
+            },
+            {
+                "has_audio": true,
+                "framerate": 25,
+                "description": "",
+                "bitrate": 164218,
+                "url": "h264-360p.mp4",
+                "has_video": true,
+                "tags": [
+                    "player-download",
+                    "tube-download"
+                ],
+                "flavor": "delivery/h264-360p",
+                "duration": 52200,
+                "size": -1,
+                "framecount": 1305,
+                "checksum": "e00e7337bffd6621f8a5a74a86518f8e (md5)",
+                "width": 640,
+                "id": "55a6475f-002d-4734-8ad4-0126bc9d8695",
+                "mediatype": "video/mp4",
+                "height": 360
+            }
+        ],
+        "mediatype": "",
+        "url": "https://player.cast-test.switch.ch?tenant=ethz-ch&id=3797f4b9-6546-4efb-aa00-66f1c3efb394"
+    }
+]

--- a/tests/opencast_repository_test.php
+++ b/tests/opencast_repository_test.php
@@ -1,0 +1,88 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * @package    repository_opencast
+ * @copyright  2018 Andreas Wagner, SYNERGY LEARNING
+ * @author     Andreas Wagner
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+defined('MOODLE_INTERNAL') || die();
+
+class repository_opencast_testcase extends advanced_testcase {
+
+    public function test_add_video_published_data() {
+        global $CFG, $DB;
+
+        require_once($CFG->dirroot . '/repository/opencast/lib.php');
+
+        $this->resetAfterTest(true);
+        $this->setAdminUser();
+
+        $publications = json_decode(file_get_contents($CFG->dirroot . '/repository/opencast/tests/fixtures/testdata.js'));
+        $repository = $DB->get_record_sql(
+            "SELECT i.id
+             FROM {repository_instances} i
+             JOIN {repository} r on r.id = i.typeid AND r.type = ?", ['opencast']
+        );
+        $repository = new repository_opencast($repository->id);
+
+        $video = new \stdClass();
+        $video->title = 'Test';
+
+        // Checking without setup repository.
+        $video = $repository->phpu_adapter_test_listing($publications, $video);
+        $this->assertTrue(!isset($video->thumbnail));
+
+        $publications[0]->channel = 'api';
+        $video = $repository->phpu_adapter_test_listing($publications, $video);
+        $this->assertEquals($video->url, 'h264-540p.mp4');
+        $this->assertEquals($video->title, 'Test.mp4');
+        $this->assertEquals($video->thumbnail, 'tn_presentation_search_preview_1.png');
+
+        // Setup the repository type.
+        set_config('opencast_channelid', 'switchcast-player', 'opencast');
+        set_config('opencast_thumbnailflavor', 'presenter/search+preview', 'opencast');
+        set_config('opencast_thumbnailflavorfallback', 'presentation/search+preview', 'opencast');
+        set_config('opencast_videoflavor', 'delivery/h264-720p', 'opencast');
+
+        $publications[0]->channel = 'switchcast-player';
+
+        $video = new \stdClass();
+        $video->title = 'Test';
+
+        $video = $repository->phpu_adapter_test_listing($publications, $video);
+        $this->assertEquals($video->url, 'h264-720p.mp4');
+        $this->assertEquals($video->title, 'Test.mp4');
+        $this->assertEquals($video->thumbnail, 'tn_presenter_search_preview_1.png');
+
+        set_config('opencast_channelid', 'switchcast-player', 'opencast');
+        set_config('opencast_thumbnailflavor', 'notvalid', 'opencast');
+        set_config('opencast_thumbnailflavorfallback', 'presentation/search+preview', 'opencast');
+        set_config('opencast_videoflavor', 'delivery/h264-720p', 'opencast');
+
+        $publications[0]->channel = 'switchcast-player';
+
+        $video = new \stdClass();
+        $video->title = 'Test';
+
+        $video = $repository->phpu_adapter_test_listing($publications, $video);
+        $this->assertEquals($video->url, 'h264-720p.mp4');
+        $this->assertEquals($video->title, 'Test.mp4');
+        $this->assertEquals($video->thumbnail, 'tn_presentation_search_preview_1.png');
+    }
+
+}

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2018052300;        // The current plugin version (Date: YYYYMMDDXX)
+$plugin->version   = 2018052301;        // The current plugin version (Date: YYYYMMDDXX)
 $plugin->requires  = 2015050500;        // Requires this Moodle version
 $plugin->component = 'repository_opencast'; // Full name of the plugin (used for diagnostics).
 $plugin->dependencies = array('tool_opencast' => 2018052300);

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2017110800;        // The current plugin version (Date: YYYYMMDDXX)
+$plugin->version   = 2018052300;        // The current plugin version (Date: YYYYMMDDXX)
 $plugin->requires  = 2015050500;        // Requires this Moodle version
 $plugin->component = 'repository_opencast'; // Full name of the plugin (used for diagnostics).
-$plugin->dependencies = array('tool_opencast' => 2018013002);
+$plugin->dependencies = array('tool_opencast' => 2018052300);


### PR DESCRIPTION
It is now possible to define multiple instances of opencast repositories.
Each can define
- the publication channel, which is relevant for filtering the set of available videos,
- the flavour, which is relevant for the selection of a suitable thumbnail and
- a boolean value, which states how the video is included. Either as a video file url, which will be exchanged by the media filter plugin of moodle, or as a url to the player of the publication, which could be exchanged by the opencast filter plugin.
